### PR TITLE
Missing NAlt and NCT in HMXL + EstimOpt.RealMin

### DIFF
--- a/DCE_tools/DataClean.m
+++ b/DCE_tools/DataClean.m
@@ -133,6 +133,10 @@ if isfield(EstimOpt,'ApproxHess') == 0 || (EstimOpt.ApproxHess ~= 0 && EstimOpt.
 	EstimOpt.ApproxHess = 1;
 end
 
+if isfield(EstimOpt,'RealMin') == 0 || (EstimOpt.RealMin ~= 0 && EstimOpt.RealMin ~= 1)
+	EstimOpt.RealMin = 0;
+end
+
 EstimOpt.Draws = 6; % 1 - pseudo-random, 2 - Latin Hypercube, 3 - Halton, 4 - Halton RR scrambled, 5 - Sobol, 6 - Sobol MAO scrambled
 EstimOpt.NSdSim = 1e4; % number of draws for simulating standard deviations
 

--- a/HMXL/HMXL.m
+++ b/HMXL/HMXL.m
@@ -635,10 +635,10 @@ if ((isfield(EstimOpt, 'ConstVarActive') == 1 && EstimOpt.ConstVarActive == 1) |
     OptimOpt.GradObj = 'on';
 end
 
-if any(EstimOpt.MissingAlt(:) == 1) && EstimOpt.NumGrad == 0
-   EstimOpt.NumGrad = 1;
-   cprintf(rgb('DarkOrange'), 'WARNING: Setting user-supplied gradient to numerical - missing alternatives not supported by analytical gradient \n')
-end
+% if any(EstimOpt.MissingAlt(:) == 1) && EstimOpt.NumGrad == 0
+%    EstimOpt.NumGrad = 1;
+%    cprintf(rgb('DarkOrange'), 'WARNING: Setting user-supplied gradient to numerical - missing alternatives not supported by analytical gradient \n')
+% end
 
 if EstimOpt.FullCov == 2 && EstimOpt.NumGrad == 0
    EstimOpt.NumGrad = 1;
@@ -895,7 +895,7 @@ for i = 1:size(INPUT.Xmea,2)
         l = l+sum(EstimOpt.MeaMatrix(:,i))+2+tmp;
     elseif EstimOpt.MeaSpecMatrix(i) == 1
         disp('Estimated using MNL')
-        for n = 1:(length(unique(INPUT.Xmea(INPUT.MissingInd==0,i)))-1)
+        for n = 1:(length(unique(INPUT.Xmea(:,i)))-1)
             disp(num2str(n+1, 'Parameters for %1.0f alternative'))
             disp('var.   coef.     st.err.  p-value')
             disp([char(EstimOpt.NamesLV(l+1:l+1+sum(EstimOpt.MeaMatrix(:,i),1)+tmp)) ,blanks(1+sum(EstimOpt.MeaMatrix(:,i),1)+tmp)',num2str(Results.DetailsM(l+1:l+1+sum(EstimOpt.MeaMatrix(:,i),1)+tmp,1), '%11.4f'), star_sig(Results.DetailsM(l+1:l+1+sum(EstimOpt.MeaMatrix(:,i),1)+tmp,3)), num2str(Results.DetailsM(l+1:l+1+sum(EstimOpt.MeaMatrix(:,i),1)+tmp,2:3),'%8.4f %8.4f')])
@@ -907,15 +907,15 @@ for i = 1:size(INPUT.Xmea,2)
         disp([char(EstimOpt.NamesLV(l+1:l+sum(EstimOpt.MeaMatrix(:,i),1)+tmp)) ,repmat(blanks(sum(EstimOpt.MeaMatrix(:,i),1)+tmp)',1,6),num2str(Results.DetailsM(l+1:l+sum(EstimOpt.MeaMatrix(:,i))+tmp,1),'%11.4f'), star_sig(Results.DetailsM(l+1:l+sum(EstimOpt.MeaMatrix(:,i))+tmp,3)), num2str(Results.DetailsM(l+1:l+sum(EstimOpt.MeaMatrix(:,i))+tmp,2:3),'%8.4f %8.4f')])
         l = l+sum(EstimOpt.MeaMatrix(:,i))+tmp;
         disp([num2str([1, Results.DetailsM(l+1,1)],'Cutoff %1.0f %7.4f'), star_sig(Results.DetailsM(l+1,3)), num2str(Results.DetailsM(l+1,2:3),'%8.4f %8.4f')])
-        if length(unique(INPUT.Xmea(INPUT.MissingInd==0,i))) > 2 % if attitude is not binary 
-            g = [Results.DetailsM(l+1,1) ; exp(Results.DetailsM(l+2:l+length(unique(INPUT.Xmea(INPUT.MissingInd==0,i)))-1,1))];
-            for n = 2:length(unique(INPUT.Xmea(INPUT.MissingInd==0,i)))-1
+        if length(unique(INPUT.Xmea(:,i))) > 2 % if attitude is not binary 
+            g = [Results.DetailsM(l+1,1) ; exp(Results.DetailsM(l+2:l+length(unique(INPUT.Xmea(:,i)))-1,1))];
+            for n = 2:length(unique(INPUT.Xmea(:,i)))-1
                 stdx = sqrt(g(1:n)'*Results.ihess((EstimOpt.NVarstr)*EstimOpt.NLatent+l+1:(EstimOpt.NVarstr)*EstimOpt.NLatent+l+n,(EstimOpt.NVarstr)*EstimOpt.NLatent+ l+1:(EstimOpt.NVarstr)*EstimOpt.NLatent+l+n)*g(1:n));
                 Results.DetailsM(l+n,1:3) = [sum(g(1:n),1), stdx, pv(sum(g(1:n),1), stdx)];
                 disp([num2str([n, Results.DetailsM(l+n,1)],'Cutoff %1.0f %7.4f'), star_sig(Results.DetailsM(l+n,3)), num2str(Results.DetailsM(l+n,2:3),'%8.4f %8.4f')])
             end
         end       
-        l = l+length(unique(INPUT.Xmea(INPUT.MissingInd==0,i)))-1;
+        l = l+length(unique(INPUT.Xmea(:,i)))-1;
     elseif EstimOpt.MeaSpecMatrix(i) == 3
         disp('Estimated using Poisson regression')
         disp('var.   coef.     st.err.  p-value')

--- a/HMXL/LL_hmxl.asv
+++ b/HMXL/LL_hmxl.asv
@@ -222,7 +222,7 @@ if nargout == 1 % function value only
             l = l+2*size(X,2);
         end
     end
-    if EstimOpt.RealMin == 0
+    if EstimOpt.Realmin == 0
         f = -log(mean(probs.*L_mea,2));
     else
         f = -log(max(realmin,mean(probs.*L_mea,2)));
@@ -579,10 +579,8 @@ else % function value + gradient
             theta = exp(bmea(l+size(X,2)+1));
             u = theta./(theta+lam);  
             if EstimOpt.RealMin == 1
-                L = min(gamma(theta+Xmea(:,i*ones(EstimOpt.NRep,1))), realmax)./(gamma(theta).*min(gamma(Xmea(:,i*ones(EstimOpt.NRep,1))+1),realmax));
-            else
-                L = gamma(theta+Xmea(:,i*ones(EstimOpt.NRep,1)))./(gamma(theta).*gamma(Xmea(:,i*ones(EstimOpt.NRep,1))+1));
-            end
+%             L = min(gamma(theta+Xmea(:,i*ones(EstimOpt.NRep,1))), realmax)./(gamma(theta).*min(gamma(Xmea(:,i*ones(EstimOpt.NRep,1))+1),realmax));
+            L = gamma(theta+Xmea(:,i*ones(EstimOpt.NRep,1)))./(gamma(theta).*gamma(Xmea(:,i*ones(EstimOpt.NRep,1))+1));
             L = L.*(u.^theta).*((1-u).^Xmea(:,i*ones(EstimOpt.NRep,1)));
             L_mea = L_mea.*L;
             % Calculations for gradient 
@@ -626,25 +624,18 @@ else % function value + gradient
             lam = exp(fit);
             IndxZIP = Xmea(:,i) == 0;
             L(IndxZIP,:) = pzip(IndxZIP,:) + (1-pzip(IndxZIP,:)).*exp(-lam(IndxZIP,:));
-            if EstimOpt.RealMin == 1
-                L(~IndxZIP,:) = (1-pzip(~IndxZIP,:)).*exp(fit(~IndxZIP,:).*Xmea(~IndxZIP,i*ones(EstimOpt.NRep,1))-lam(~IndxZIP,:))./min(gamma(Xmea(~IndxZIP,i*ones(EstimOpt.NRep,1))+1),realmax);
-            else
-                L(~IndxZIP,:) = (1-pzip(~IndxZIP,:)).*exp(fit(~IndxZIP,:).*Xmea(~IndxZIP,i*ones(EstimOpt.NRep,1))-lam(~IndxZIP,:))./ gamma(Xmea(~IndxZIP,i*ones(EstimOpt.NRep,1))+1);
-            end
+%             L(~IndxZIP,:) = (1-pzip(~IndxZIP,:)).*exp(fit(~IndxZIP,:).*Xmea(~IndxZIP,i*ones(EstimOpt.NRep,1))-lam(~IndxZIP,:))./min(gamma(Xmea(~IndxZIP,i*ones(EstimOpt.NRep,1))+1),realmax);
+            L(~IndxZIP,:) = (1-pzip(~IndxZIP,:)).*exp(fit(~IndxZIP,:).*Xmea(~IndxZIP,i*ones(EstimOpt.NRep,1))-lam(~IndxZIP,:))./ gamma(Xmea(~IndxZIP,i*ones(EstimOpt.NRep,1))+1);
             L_mea = L_mea.*L;
 
             % Calculations for gradient 
-            grad_tmp1 = zeros(EstimOpt.NP, EstimOpt.NRep); % For ZIP 
-            grad_tmp2 = zeros(EstimOpt.NP, EstimOpt.NRep); % For Poiss
-            
-            if EstimOpt.RealMin == 1
-                grad_tmp1(IndxZIP,:) = (-(1-pzip(IndxZIP,:)).*pzip(IndxZIP,:).*exp(-lam(IndxZIP,:))+pzip(IndxZIP,:)-pzip(IndxZIP,:).^2)./max(L(IndxZIP,:),realmin);
-                grad_tmp2(IndxZIP,:) = (pzip(IndxZIP,:)-1).*exp(fit(IndxZIP,:)-lam(IndxZIP,:))./max(L(IndxZIP,:),realmin);
-            else
-                grad_tmp1(IndxZIP,:) = (-(1-pzip(IndxZIP,:)).*pzip(IndxZIP,:).*exp(-lam(IndxZIP,:))+pzip(IndxZIP,:)-pzip(IndxZIP,:).^2)./L(IndxZIP,:);
-                grad_tmp2(IndxZIP,:) = (pzip(IndxZIP,:)-1).*exp(fit(IndxZIP,:)-lam(IndxZIP,:))./L(IndxZIP,:);
-            end
+            grad_tmp1 = zeros(EstimOpt.NP, EstimOpt.NRep);
+            grad_tmp2 = zeros(EstimOpt.NP, EstimOpt.NRep);
+            % For ZIP 
+            grad_tmp1(IndxZIP,:) = (-(1-pzip(IndxZIP,:)).*pzip(IndxZIP,:).*exp(-lam(IndxZIP,:))+pzip(IndxZIP,:)-pzip(IndxZIP,:).^2)./L(IndxZIP,:);
             grad_tmp1(~IndxZIP,:) = -pzip(~IndxZIP,:);
+            % For Poiss
+            grad_tmp2(IndxZIP,:) = (pzip(IndxZIP,:)-1).*exp(fit(IndxZIP,:)-lam(IndxZIP,:))./L(IndxZIP,:);
             grad_tmp2(~IndxZIP,:) = Xmea(~IndxZIP,i*ones(EstimOpt.NRep,1)) - lam(~IndxZIP,:);
 
             LVindx = find(EstimOpt.MeaMatrix(:,i)'== 1);
@@ -677,11 +668,8 @@ else % function value + gradient
     end
 
     probs = probs.*L_mea;
-    if EstimOpt.RealMin == 1
-        p = max(realmin,mean(probs,2));
-    else    
-        p = mean(probs,2);
-    end
+%     p = max(realmin,mean(probs,2));
+    p = mean(probs,2);
     f = -log(p);
 
     gstr = reshape(gstr, EstimOpt.NP, EstimOpt.NRep, EstimOpt.NVarstr*EstimOpt.NLatent);


### PR DESCRIPTION
I changed analytical gradient in HMXL to allow estimation with missing
alternatives and choice tasks. I also added switch EstimOpt.RealMin
